### PR TITLE
Packaging min python version

### DIFF
--- a/infobip_channels/whatsapp/models/buttons_message.py
+++ b/infobip_channels/whatsapp/models/buttons_message.py
@@ -1,5 +1,10 @@
 from enum import Enum
-from typing import Literal, Optional, Union
+from typing import Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import AnyHttpUrl, conlist, constr, validator
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = infobip-channels
-version = 0.0.3
+version = 0.0.4
 author = Luka Kilic
 author_email = kilic.luka@gmail.com
 description = Infobip's channels API package
@@ -19,7 +19,7 @@ classifiers =
 package_dir =
     = .
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.6
 install_requires =
     pydantic==1.9.0
     requests==2.27.1


### PR DESCRIPTION
Python 3.6 was selected as a min version because it's the oldest one supported by `pydantic` and `requests` library.