### PR TITLE
Update pydantic for 3.11 compatibilty

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,3 @@
-pydantic==1.9.0
-requests==2.27.1
-regex==2022.3.15
+pydantic~=1.9.0
+requests~=2.31.0
+regex~=2022.3.15

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = infobip-api-python-sdk
-version = 5.0.0
+version = 5.0.1
 author = Luka Kilic, Dino Lozina, Erick Corona
 author_email = DevRel@infobip.com
 description = Python sdk for Infobip's API

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,9 @@ package_dir =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    pydantic==1.9.0
-    requests==2.27.1
-    regex==2022.3.15
+    pydantic~=1.10.8
+    requests~=2.31.0
+    regex~=2022.3.15
 
 [options.packages.find]
 where = .

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
 
 [testenv]
 deps =
-    pydantic==1.9.0
+    pydantic==1.10.8
     requests==2.27.1
     pytest==6.2.5
     pytest-cov==3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ env_list =
     py38
     py39
     py310
+    py311
     report
 
 [gh-actions]
@@ -11,11 +12,12 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 deps =
     pydantic==1.10.8
-    requests==2.27.1
+    requests==2.31.0
     pytest==6.2.5
     pytest-cov==3.0.0
     pytest-httpserver==1.0.4
@@ -24,8 +26,8 @@ deps =
     pytest-cov==3.0.0
     regex==2022.3.15
 depends =
-    {py38, py39, py310}: clean
-    report: py38, py39, py310
+    {py38, py39, py310, py311}: clean
+    report: py38, py39, py310, py311
 commands = python -m pytest --cov-append --cov=infobip_channels --cov=infobip_platform tests/
 
 [testenv:report]


### PR DESCRIPTION
This PR includes the following changes:
* Update Pydantic for Python 3.11 compatibility.
* Use 'compatible' operator for dependencies.
* Update requests to 2.31.0 for security.