### PR TITLE
Add South Korea field option to Regional parameters for SMS

### DIFF
--- a/infobip_channels/sms/models/body/core.py
+++ b/infobip_channels/sms/models/body/core.py
@@ -53,9 +53,14 @@ class TurkeyIys(CamelCaseModel):
     recipient_type: TurkeyRecipientTypeEnum
 
 
+class SouthKorea(CamelCaseModel):
+    reseller_code: Optional[int]
+
+
 class Regional(CamelCaseModel):
     india_dlt: Optional[IndiaDlt] = None
     turkey_iys: Optional[TurkeyIys] = None
+    south_korea: Optional[SouthKorea] = None
 
 
 class Time(CamelCaseModel):


### PR DESCRIPTION
Addresses https://github.com/infobip-community/infobip-api-python-sdk/issues/93