### PR TITLE
Add `CoreMixin` to WhatsApp generic `MessageBody `

### DIFF
--- a/infobip_channels/whatsapp/models/body/core.py
+++ b/infobip_channels/whatsapp/models/body/core.py
@@ -2,10 +2,14 @@ from typing import Optional
 
 from pydantic import AnyHttpUrl, Field, constr, validator
 
-from infobip_channels.core.models import MessageBodyBase, UrlLengthValidatorMixin
+from infobip_channels.core.models import (
+    CoreMixin,
+    MessageBodyBase,
+    UrlLengthValidatorMixin,
+)
 
 
-class MessageBody(UrlLengthValidatorMixin, MessageBodyBase):
+class MessageBody(CoreMixin, UrlLengthValidatorMixin, MessageBodyBase):
     from_number: constr(min_length=1, max_length=24) = Field(alias="from")
     to: constr(min_length=1, max_length=24)
     message_id: Optional[constr(max_length=50)] = None

--- a/tests/whatsapp/models/test_text_message.py
+++ b/tests/whatsapp/models/test_text_message.py
@@ -39,6 +39,8 @@ def test_when_input_data_is_valid__validation_error_is_not_raised():
                 "to": "38598451987",
                 "content": {"text": "a test message", "previewUrl": True},
                 "callbackData": "Some data",
+                "application_id": "An ID",
+                "entity_id": "Another ID",
             }
         )
     except ValidationError:


### PR DESCRIPTION
This introduces `entityId` and `applicationId` to all WhatsApp message types.

Addresses https://github.com/infobip-community/infobip-api-python-sdk/issues/108